### PR TITLE
when the user logs in, they need to be redirected to their profile page

### DIFF
--- a/src/components/Account/LoginForm.tsx
+++ b/src/components/Account/LoginForm.tsx
@@ -50,7 +50,7 @@ export default function LoginForm() {
 					loggedIn: data?.loginWithCookies?.status ? true : false,
 				}));
 
-				router.push("/account");
+				router.push("/account/profile");
 			})
 			.catch((error) => {
 				console.error(error);


### PR DESCRIPTION
Corrected the router path to go the `/account/profile` instead of `/account`, which is not currently a page.